### PR TITLE
Fix Dockerfile PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ USER root
 
 # Install Amazon Corretto 21
 ENV JAVA_HOME=/opt/amazon-corretto-21
-ENV PATH="$JAVA_HOME/bin:$PATH"
+ENV PATH=$JAVA_HOME/bin:$PATH
 
 RUN curl -L -o corretto21.tar.gz https://corretto.aws/downloads/latest/amazon-corretto-21-x64-linux-jdk.tar.gz \
     && mkdir -p /opt/amazon-corretto-21 \


### PR DESCRIPTION
## Summary
- correct the PATH environment variable syntax in Dockerfile

## Testing
- `docker build -t jenkins-ecs-fargate-test .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b68a261fc832b91ece9e6ed5c53b9