### PR TITLE
Add Jenkins smoke test in ECR workflow

### DIFF
--- a/.github/workflows/docker-to-ecr.yml
+++ b/.github/workflows/docker-to-ecr.yml
@@ -32,3 +32,15 @@ jobs:
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
+      - name: Smoke test Jenkins container
+        env:
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          IMAGE_TAG: demo
+        run: |
+          docker run -d --name jenkins-test -p 8080:8080 $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          sleep 30
+          curl --fail http://localhost:8080/login
+          docker stop jenkins-test
+          docker rm jenkins-test
+


### PR DESCRIPTION
## Summary
- run Jenkins container after pushing to ECR
- check that Jenkins is reachable before stopping the container

## Testing
- `yamllint .github/workflows/docker-to-ecr.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b6956f1a0832b9710e569a2584c0d